### PR TITLE
Avoid ASG dropping Target Group attachments

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -13,6 +13,10 @@ resource "aws_autoscaling_group" "jenkins" {
   health_check_grace_period = var.health_check_grace_period
   health_check_type         = var.health_check_type
 
+  lifecycle {
+    ignore_changes = [load_balancers, target_group_arns]
+  }
+
   dynamic "tag" {
     for_each = var.asg_tags
     content {


### PR DESCRIPTION
As per Terraform documentation, when ASG is used as a Target Group for Load Balancer (either ALB or ELB), lifecycle must be configured to ignore `load_balancers` and `target_group_arns` arguments.

If lifecycle is not present, every subsequent `terraform plan` will propose detaching of ASG from the LB target group.

See [this page][1] in Terraform documentation.

[1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group