### PR TITLE
Retry mounting EFS filesystem for 10 minutes

### DIFF
--- a/userdata.sh
+++ b/userdata.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Mounting will be retried for 10 minutes (60 retries x 10 seconds)
+efs_mount_max_retry=60
+efs_mount_retry_sleep=10
+# Recommended mount options are explained here:
+# https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
+efs_mount_command='mount -t nfs -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${efs_dnsname}:/ /efsmnt'
+
 awk -F= '/^NAME/{print $2}' /etc/os-release | grep -i ubuntu
 RESULTUBUNTU=$?
 if [ $RESULTUBUNTU -eq 0 ]; then
@@ -15,7 +22,19 @@ if [ $RESULTUBUNTU -eq 0 ]; then
   # Create EFS mount folder & mount
   /usr/bin/apt-get install nfs-common -y
   mkdir /efsmnt
-  mount -t nfs -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${efs_dnsname}:/ /efsmnt
+  echo 'Attempting to mount EFS filesystem ${efs_dnsname}...'
+  counter=0
+  until $efs_mount_command
+  do
+    sleep $efs_mount_retry_sleep
+    [[ $counter -eq $efs_mount_max_retry ]] && echo 'EFS mount failed! Mounting aborted, local disk will be used instead. Aborting...' && exit 1
+    echo "Retrying to mount EFS filesystem ${efs_dnsname}... (retry #$counter)"
+    ((counter++))
+  done
+  echo 'Mounting done.'
+  echo '------- Output of `mount | grep /efsmnt`: ------'
+  mount | grep /efsmnt
+  echo '------- End of output ------'
   echo '${efs_dnsname}:/ /efsmnt nfs defaults,_netdev 0 0' >> /etc/fstab
   # Install Jenkins
   wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo apt-key add -
@@ -51,7 +70,19 @@ if [ $RESULTAMAZON -eq 0 ]; then
   # Create EFS mount folder & mount
   /bin/yum -y install nfs-utils
   mkdir /efsmnt
-  mount -t nfs -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${efs_dnsname}:/ /efsmnt
+  echo 'Attempting to mount EFS filesystem ${efs_dnsname}...'
+  counter=0
+  until $efs_mount_command
+  do
+    sleep $efs_mount_retry_sleep
+    [[ $counter -eq $efs_mount_max_retry ]] && echo 'EFS mount failed! Mounting aborted, local disk will be used instead. Aborting...' && exit 1
+    echo "Retrying to mount EFS filesystem ${efs_dnsname}... (retry #$counter)"
+    ((counter++))
+  done
+  echo 'Mounting done.'
+  echo '------- Output of `mount | grep /efsmnt`: ------'
+  mount | grep /efsmnt
+  echo '------- End of output ------'
   echo '${efs_dnsname}:/ /efsmnt nfs defaults,_netdev 0 0' >> /etc/fstab
   # Install Jenkins
   /bin/curl --silent --location http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo | sudo tee /etc/yum.repos.d/jenkins.repo


### PR DESCRIPTION
[As recommended by AWS][1], instance should wait for 90 seconds before mounting of EFS filesystem is attempted (assuming EFS filesystem was _just_ created), to allow sufficient time for DNS name associated with EFS filesystem to propagate, and for mounting to be successful. In my experiments, I experienced much longer DNS propagation delay of around 5 minutes.

This patch introduces a retry mechanism into the mounting process. Mounting will fail instantly as soon as DNS resolution fails.

In case that mounting does not succeed after retrying for 10 minutes, the user script will `exit(1)`, which will prevent Jenkins from being installed. Eventually, ALB should figure out that the instance is permanently unhealthy, and ASG will rebuild it.

Fixes #8 

[1]: https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html