### PR TITLE
Update example module version

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -7,7 +7,7 @@ module "jenkins" {
   ]
 
   source  = "Cloud-42/jenkins/aws"
-  version = "5.0.0"
+  version = "5.2.0"
   
   instance_type        = "t3a.medium"
   iam_instance_profile = module.jenkins-role.profile.name


### PR DESCRIPTION
Update the example to grab the latest version of the module that fixes the jenkins installation, otherwise the module will not install jenkins on the AWS AMI. This might prevent users from using this module.