### PR TITLE
Removing deprecated template provider in favor of templatefile() method

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.13.0"
+  hashes = [
+    "h1:3reDkc0ysWUlUFPFL/mLZDlPNODFDMF8s66DEEx4xIY=",
+    "zh:215226bc0372077d2ae6dba4e2f08f6361f8e4953d20bc4c682d40fdf5002544",
+    "zh:42777cbdc046181986c0260ea17027ef1364c31d73a57eb0ab539f6e1a3e0780",
+    "zh:78079d2f5fc35f3c43eb2a131cb49c2c77ddd04943bca97080f33355808d39cc",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c0404a044eae741f10f3d217dc28658e0f04082963918913b024d3305c11e79",
+    "zh:a1b5a53f60d4f7bff1cc84180fef6205c95b8793741dbc8c0564a6200424ca73",
+    "zh:ba6711064a855ddb55924342b70667e9bed660bde8552dc0bde4b7f8947a2ec4",
+    "zh:d0f77ed514d54f7380d7e1ef585d853f50f1bee381d6abbf3a68429b68de6045",
+    "zh:d5c454d2ac9aed01ae00c477192c93d54c8362357a87684a3171055dcec25f44",
+    "zh:dfd381ed7da945cb85b99df843ee7eab339dd1799fa70d1ad3e94331605aad01",
+    "zh:eb6dc84414714f61b9de0ac190c69f598af9b16d144a44f573df484c06c8d4ef",
+    "zh:f02e79599af3f8f63e4b885c5715be3a4060cbf98eb4bf46d616aa0d9f2b5cd3",
+  ]
+}

--- a/lc.tf
+++ b/lc.tf
@@ -9,7 +9,7 @@ resource "aws_launch_configuration" "jenkins" {
   iam_instance_profile = var.iam_instance_profile
   security_groups      = var.security_groups
   enable_monitoring    = var.enable_monitoring
-  user_data            = var.custom_userdata != "" ? var.custom_userdata : data.template_file.user_data.rendered
+  user_data            = var.custom_userdata != "" ? var.custom_userdata : local.user_data_contents
 
   # Setup root block device
   root_block_device {
@@ -27,16 +27,14 @@ resource "aws_launch_configuration" "jenkins" {
 # --------------------------
 # Render userdata bootstrap file
 # --------------------------
-data "template_file" "user_data" {
-  template = file("${path.module}/userdata.sh")
-
-  vars = {
+locals {
+  user_data_contents = templatefile("${path.module}/userdata.sh", {
     appliedhostname         = var.hostname_prefix
     domain_name             = var.domain_name
     environment             = var.environment
     efs_dnsname             = aws_efs_file_system.this.dns_name
     preliminary_user_data   = var.preliminary_user_data
     supplementary_user_data = var.supplementary_user_data
-  }
+  })
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,8 +5,5 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
-    template = {
-      source = "hashicorp/template"
-    }
   }
 }


### PR DESCRIPTION
Since Terraform 0.12, the template provider has been [superseded by the `templatefile` function](https://registry.terraform.io/providers/hashicorp/template/latest/docs#template_file). This is a backwards-compatible change to support the newer function.